### PR TITLE
Xcode version update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v1
       with:
         fetch-depth: 1
-    - run: sudo xcode-select -switch /Applications/Xcode_11.2.app
+    - run: sudo xcode-select -switch /Applications/Xcode_11.3.app
     - run: |
         cd Mobile
-        xcodebuild -project CarWashService.xcodeproj -scheme CarWashService -destination platform\=iOS\ Simulator,OS\=13.2,name\=iPhone\ 11\ Pro\ Max build
+        xcodebuild -project CarWashService.xcodeproj -scheme CarWashService -destination platform\=iOS\ Simulator,OS\=13.3,name\=iPhone\ 11\ Pro\ Max build

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ matrix:
         - dotnet build
     - name: "Mobile"
       language: swift
-      osx_image: xcode11.2
+      osx_image: xcode11.3
       before_install: cd Mobile
-      script: xcodebuild -project CarWashService.xcodeproj -scheme CarWashService -destination platform\=iOS\ Simulator,OS\=13.2.2,name\=iPhone\ 11\ Pro\ Max build
+      script: xcodebuild -project CarWashService.xcodeproj -scheme CarWashService -destination platform\=iOS\ Simulator,OS\=13.3,name\=iPhone\ 11\ Pro\ Max build


### PR DESCRIPTION
- Travis CI still is not ready to work with Xcode 11.3, so these builds failed.
- GitHub Actions works good.